### PR TITLE
feat: add admin management panel

### DIFF
--- a/Proyecto/src/components/Dashboard.jsx
+++ b/Proyecto/src/components/Dashboard.jsx
@@ -1,19 +1,56 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  updateDoc,
+} from "firebase/firestore";
+import { auth, db } from "../firebase";
 
 export default function Dashboard() {
   const navigate = useNavigate();
+  const [users, setUsers] = useState([]);
+  const [posts, setPosts] = useState([]);
+
+  const fetchUsers = async () => {
+    const snapshot = await getDocs(collection(db, "users"));
+    setUsers(snapshot.docs.map((d) => ({ id: d.id, ...d.data() })));
+  };
+
+  const fetchPosts = async () => {
+    const snapshot = await getDocs(collection(db, "posts"));
+    setPosts(snapshot.docs.map((d) => ({ id: d.id, ...d.data() })));
+  };
+
+  useEffect(() => {
+    fetchUsers();
+    fetchPosts();
+  }, []);
 
   const handleLogout = () => {
-    // Aquí puedes llamar a auth.signOut() si usas Firebase Auth
-    // auth.signOut().then(() => navigate('/login'));
-    navigate("/login");
+    auth.signOut().then(() => navigate("/login"));
+  };
+
+  const handleToggleSuspend = async (user) => {
+    await updateDoc(doc(db, "users", user.id), {
+      suspended: !user.suspended,
+    });
+    setUsers((prev) =>
+      prev.map((u) =>
+        u.id === user.id ? { ...u, suspended: !u.suspended } : u
+      )
+    );
+  };
+
+  const handleDeletePost = async (postId) => {
+    await deleteDoc(doc(db, "posts", postId));
+    setPosts((prev) => prev.filter((p) => p.id !== postId));
   };
 
   return (
     <div className="d-flex vh-100 flex-column">
-
-      {/* Navbar superior */}
       <nav className="navbar navbar-dark bg-primary px-4">
         <span className="navbar-brand mb-0 h1">Panel de Administración</span>
         <button className="btn btn-outline-light" onClick={handleLogout}>
@@ -22,79 +59,26 @@ export default function Dashboard() {
       </nav>
 
       <div className="d-flex flex-grow-1">
-
-        {/* Sidebar */}
         <nav
           className="bg-light border-end d-none d-md-flex flex-column p-3"
           style={{ width: "220px" }}
         >
           <ul className="nav nav-pills flex-column mb-auto">
             <li className="nav-item mb-2">
-              <a href="#resumen" className="nav-link link-dark">
-                Resumen
-              </a>
-            </li>
-            <li className="nav-item mb-2">
-              <a href="#graficos" className="nav-link link-dark">
-                Gráficos
-              </a>
-            </li>
-            <li className="nav-item mb-2">
               <a href="#usuarios" className="nav-link link-dark">
                 Usuarios
               </a>
             </li>
             <li className="nav-item mb-2">
-              <a href="#configuracion" className="nav-link link-dark">
-                Configuración
+              <a href="#posts" className="nav-link link-dark">
+                Publicaciones
               </a>
             </li>
           </ul>
         </nav>
 
-        {/* Contenido principal */}
         <main className="flex-grow-1 overflow-auto p-4">
-          {/* Resumen */}
-          <section id="resumen" className="mb-5">
-            <h3>Resumen</h3>
-            <div className="row g-3">
-              <div className="col-md-4">
-                <div className="card text-white bg-primary">
-                  <div className="card-body">
-                    <h5 className="card-title">Usuarios Registrados</h5>
-                    <p className="card-text display-4">120</p>
-                  </div>
-                </div>
-              </div>
-              <div className="col-md-4">
-                <div className="card text-white bg-success">
-                  <div className="card-body">
-                    <h5 className="card-title">Ventas Hoy</h5>
-                    <p className="card-text display-4">$4,500</p>
-                  </div>
-                </div>
-              </div>
-              <div className="col-md-4">
-                <div className="card text-white bg-warning">
-                  <div className="card-body">
-                    <h5 className="card-title">Tickets Pendientes</h5>
-                    <p className="card-text display-4">8</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          {/* Gráficos (placeholder) */}
-          <section id="graficos" className="mb-5">
-            <h3>Gráficos</h3>
-            <div className="p-5 bg-light border rounded text-center">
-              <p className="text-muted">Aquí puedes insertar gráficos (Chart.js, Recharts, etc.)</p>
-            </div>
-          </section>
-
-          {/* Tabla de usuarios */}
-          <section id="usuarios">
+          <section id="usuarios" className="mb-5">
             <h3>Usuarios</h3>
             <div className="table-responsive">
               <table className="table table-striped table-hover">
@@ -104,28 +88,65 @@ export default function Dashboard() {
                     <th>Correo</th>
                     <th>Rol</th>
                     <th>Estado</th>
+                    <th>Acción</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {/* Ejemplo estático, reemplaza con datos reales */}
+                  {users.map((u) => (
+                    <tr key={u.id}>
+                      <td>{`${u.nombre || ""} ${u.apellido || ""}`}</td>
+                      <td>{u.email}</td>
+                      <td>{u.role}</td>
+                      <td>
+                        <span
+                          className={`badge ${
+                            u.suspended ? "bg-danger" : "bg-success"
+                          }`}
+                        >
+                          {u.suspended ? "Suspendido" : "Activo"}
+                        </span>
+                      </td>
+                      <td>
+                        <button
+                          className="btn btn-sm btn-warning"
+                          onClick={() => handleToggleSuspend(u)}
+                        >
+                          {u.suspended ? "Reactivar" : "Suspender"}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="posts">
+            <h3>Publicaciones</h3>
+            <div className="table-responsive">
+              <table className="table table-striped table-hover">
+                <thead>
                   <tr>
-                    <td>Ana Pérez</td>
-                    <td>ana@example.com</td>
-                    <td>Admin</td>
-                    <td><span className="badge bg-success">Activo</span></td>
+                    <th>Autor</th>
+                    <th>Contenido</th>
+                    <th>Acción</th>
                   </tr>
-                  <tr>
-                    <td>Carlos Gómez</td>
-                    <td>carlos@example.com</td>
-                    <td>Usuario</td>
-                    <td><span className="badge bg-secondary">Inactivo</span></td>
-                  </tr>
-                  <tr>
-                    <td>Laura Martínez</td>
-                    <td>laura@example.com</td>
-                    <td>Usuario</td>
-                    <td><span className="badge bg-success">Activo</span></td>
-                  </tr>
+                </thead>
+                <tbody>
+                  {posts.map((p) => (
+                    <tr key={p.id}>
+                      <td>{p.userName || "Usuario anónimo"}</td>
+                      <td>{p.text?.slice(0, 50)}</td>
+                      <td>
+                        <button
+                          className="btn btn-sm btn-danger"
+                          onClick={() => handleDeletePost(p.id)}
+                        >
+                          Eliminar
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </div>
@@ -135,3 +156,4 @@ export default function Dashboard() {
     </div>
   );
 }
+

--- a/Proyecto/src/components/ProtectedRoute.jsx
+++ b/Proyecto/src/components/ProtectedRoute.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
-import { auth } from "../firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { auth, db } from "../firebase";
 import { Navigate } from "react-router-dom";
 
 // Importa FontAwesomeIcon para renderizar íconos
@@ -12,9 +13,24 @@ export default function ProtectedRoute({ children }) {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-      setLoading(false);
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      if (currentUser) {
+        const checkSuspended = async () => {
+          const snap = await getDoc(doc(db, "users", currentUser.uid));
+          if (snap.exists() && snap.data().suspended) {
+            await auth.signOut();
+            alert("Tu cuenta ha sido suspendida.");
+            setUser(null);
+          } else {
+            setUser(currentUser);
+          }
+          setLoading(false);
+        };
+        checkSuspended();
+      } else {
+        setUser(null);
+        setLoading(false);
+      }
     });
     return unsubscribe;
   }, []);

--- a/Proyecto/src/components/SignUp.jsx
+++ b/Proyecto/src/components/SignUp.jsx
@@ -31,6 +31,7 @@ export default function SignUp() {
         apellido,
         email: user.email,
         role: "user",
+        suspended: false,
         createdAt: new Date(),
       });
       sendWelcomeEmail();


### PR DESCRIPTION
## Summary
- add admin dashboard listing users and posts with management actions
- prevent suspended users from accessing protected pages
- store suspension flag when registering new accounts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898af6df0708327ab02bb5c1907004b