### PR TITLE
feat: add admin management panel

### DIFF
--- a/Proyecto/src/components/ProtectedRoute.jsx
+++ b/Proyecto/src/components/ProtectedRoute.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
-import { auth } from "../firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { auth, db } from "../firebase";
 import { Navigate } from "react-router-dom";
 
 // Importa FontAwesomeIcon para renderizar íconos
@@ -12,9 +13,24 @@ export default function ProtectedRoute({ children }) {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-      setLoading(false);
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      if (currentUser) {
+        const checkSuspended = async () => {
+          const snap = await getDoc(doc(db, "users", currentUser.uid));
+          if (snap.exists() && snap.data().suspended) {
+            await auth.signOut();
+            alert("Tu cuenta ha sido suspendida.");
+            setUser(null);
+          } else {
+            setUser(currentUser);
+          }
+          setLoading(false);
+        };
+        checkSuspended();
+      } else {
+        setUser(null);
+        setLoading(false);
+      }
     });
     return unsubscribe;
   }, []);

--- a/Proyecto/src/components/SignUp.jsx
+++ b/Proyecto/src/components/SignUp.jsx
@@ -31,6 +31,7 @@ export default function SignUp() {
         apellido,
         email: user.email,
         role: "user",
+        suspended: false,
         createdAt: new Date(),
       });
       sendWelcomeEmail();


### PR DESCRIPTION
## Summary
- expand dashboard with user and post moderation while keeping original sections
- allow admins to suspend/reactivate users and delete posts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898af6df0708327ab02bb5c1907004b